### PR TITLE
Publish sftp port

### DIFF
--- a/docker-compose.extra.yml
+++ b/docker-compose.extra.yml
@@ -46,5 +46,6 @@ cron:
 sftp:
   image: ccarney16/pterodactyl-sftp:v1.0.1
   restart: always
+  ports: [2022:2022]
   volumes_from:
   - daemon


### PR DESCRIPTION
Port 2022 is exposed in https://github.com/ccarney16/pterodactyl-docker/blob/master/manifest/sftp/Dockerfile but does not seem to be published in the compose file, which I think is required