### PR TITLE
update daemon Dockerfile to node 10

### DIFF
--- a/manifest/daemon/Dockerfile
+++ b/manifest/daemon/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:10-alpine
 
 MAINTAINER Cameron Carney <ccarney16@live.com>
 


### PR DESCRIPTION
The latest pter daemon only works on node 10. 8 would cause errors on build.