### PR TITLE
Remove bin/yq binary and make bin/deploy use the docker image instead

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -55,7 +55,8 @@ function _return_help {
 
 function yq {
     local yq_version="3"
-    docker run --rm -i -v "${PWD}":/workdir mikefarah/yq:$yq_version "$@"
+    [[ ${yq_version:0:1} = 3 ]] && local cmd=yq
+    docker run --rm -i -v "${PWD}":/workdir mikefarah/yq:$yq_version $cmd "$@"
 }
 
 function build_config {

--- a/bin/deploy
+++ b/bin/deploy
@@ -53,6 +53,11 @@ function _return_help {
     echo ""
 }
 
+function yq {
+    local yq_version="3"
+    docker run --rm -i -v "${PWD}":/workdir mikefarah/yq:$yq_version "$@"
+}
+
 function build_config {
     >&2 echo "Building Configuration..."
 
@@ -65,7 +70,7 @@ function build_config {
 
     # Build the base config
     # Such a hacky way to do this, but it does appear to be cleaner
-    bin/yq merge -a append -x \
+    yq merge -a append -x \
     $( # Enable Panel
         if [ "$flag_enable_panel" == "x" ]; then 
             printf " ./manifest/compose/panel.yml"
@@ -105,7 +110,7 @@ function build_config {
                 printf " ./manifest/compose/database/panel.dep.yml"
             fi
         fi ) \
-    | bin/yq read --stripComments - > $flag_stdout
+    | yq read --stripComments - > $flag_stdout
 
 
     # Build .env Configuration


### PR DESCRIPTION
resolves #105

I can understand the wariness of some random binary in a repo, so i didn't see a reason not to make this happen.
Not like we wont have docker if this repo is used anyway, right?

Technically one can get rid of the bin folder entirely now, and just have deploy in the root, but i figured if anyone would do that it would be the maintainer, eh?

Made sure it was the right version, and its easy enough to change or pin later anyway.