### PR TITLE
[Fix] Panel docker build broken without php7-sodium dependency

### DIFF
--- a/manifest/images/panel/Dockerfile
+++ b/manifest/images/panel/Dockerfile
@@ -4,7 +4,7 @@ LABEL MAINTAINER="Cameron Carney <ccarney16@live.com>"
 
 RUN \
     apk --update add curl gettext nginx php7 php7 php7-bcmath php7-common php7-dom php7-fileinfo \
-    php7-fpm php7-gd php7-memcached php7-mbstring php7-openssl php7-pdo php7-phar php7-json \
+    php7-fpm php7-gd php7-memcached php7-mbstring php7-openssl php7-pdo php7-phar php7-json php7-sodium \
     php7-pdo_mysql php7-session php7-simplexml php7-tokenizer php7-ctype php7-zlib php7-zip php7-xmlwriter \
     tini \
     && mkdir -p /var/www/html /run/nginx /etc/nginx/conf.d/


### PR DESCRIPTION
Due to composer errors not aborting the docker build a faulty image was pushed and renders the panel non-functional.
```
  Problem 1
    - lcobucci/jwt is locked to version 4.1.4 and an update of this package was not requested.
    - lcobucci/jwt 4.1.4 requires ext-sodium * -> it is missing from your system. Install or enable PHP's sodium extension.
```
Adding the `php7-sodium` package solves this and makes composer pull all deps again.