### PR TITLE
Fix Container Startup Problem

### DIFF
--- a/manifest/compose/database/database.yml
+++ b/manifest/compose/database/database.yml
@@ -4,7 +4,7 @@
 # This compose file provides the required dependencies for 
 # Pterodactyl, such as MariaDB and Redis.
 ##
-version: '2.3'
+version: '3.4'
 services:
     ##
     # --MariaDB--
@@ -12,10 +12,14 @@ services:
     # Stores Server/User information
     ##
     mysql:
-      image: docker.io/library/mariadb:10.6
-      env_file: ./conf.d/mariadb.env
-      ports:
+    image: docker.io/library/mariadb:10.6
+    env_file: ./configs/mariadb.env
+    ports:
       - ${MYSQL_ADDRESS:-3306}
-      restart: always
-      volumes:
+    restart: on-failure
+    volumes:
       - ./data/db:/var/lib/mysql
+    healthcheck:
+      test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+      timeout: 20s
+      retries: 5

--- a/manifest/compose/database/database.yml
+++ b/manifest/compose/database/database.yml
@@ -13,7 +13,7 @@ services:
     ##
     mysql:
     image: docker.io/library/mariadb:10.6
-    env_file: ./configs/mariadb.env
+    env_file: ./conf.d/mariadb.env
     ports:
       - ${MYSQL_ADDRESS:-3306}
     restart: on-failure

--- a/manifest/compose/database/database.yml
+++ b/manifest/compose/database/database.yml
@@ -12,14 +12,14 @@ services:
     # Stores Server/User information
     ##
     mysql:
-    image: docker.io/library/mariadb:10.6
-    env_file: ./conf.d/mariadb.env
-    ports:
-      - ${MYSQL_ADDRESS:-3306}
-    restart: on-failure
-    volumes:
-      - ./data/db:/var/lib/mysql
-    healthcheck:
-      test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
-      timeout: 20s
-      retries: 5
+      image: docker.io/library/mariadb:10.6
+      env_file: ./conf.d/mariadb.env
+      ports:
+        - ${MYSQL_ADDRESS:-3306}
+      restart: on-failure
+      volumes:
+        - ./data/db:/var/lib/mysql
+      healthcheck:
+        test: mysqladmin ping -h 127.0.0.1 -u $$MYSQL_USER --password=$$MYSQL_PASSWORD
+        timeout: 20s
+        retries: 5

--- a/manifest/compose/database/panel.dep.yml
+++ b/manifest/compose/database/panel.dep.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '3.4'
 services:
   ##
   # panel
@@ -8,4 +8,4 @@ services:
   panel:
     depends_on:
       mysql:
-        condition: service_started
+        condition: service_healthy

--- a/manifest/compose/panel.yml
+++ b/manifest/compose/panel.yml
@@ -1,4 +1,4 @@
-version: '2.3'
+version: '3.4'
 services:
   ##
   # --Pterodactyl Panel--
@@ -13,7 +13,7 @@ services:
     ports:
     - 80:80
     - 443:443
-    restart: always
+    restart: on-failure
     volumes:
     - ./data/panel:/data
     # Enable Let's Encrypt Support


### PR DESCRIPTION
Currently the base file generated by the script contains a small problem with container initialization.
It is not a serious problem, but a fix for better container performance, at least for its first startup.

### Current behavior:
When doing the first container initialization, mysql is started along with the cache, but before mysql completes its initialization, the panel starts to be initialized.
This leads to a pile of unsuccessful attempts to connect to mysql, and in some of my tests, the panel could not connect at all, requiring a new startup attempt.

### New Behavior:
This pull request makes some changes so that the panel container starts only when the mysql container is started, and accepting connections.
This will ensure that all containers can boot correctly.

Just one example of the problem: #131