### PR TITLE
Link to the wiki in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Pterodactyl, a free an open source agnostic game panel... In a Container!
 
 ## Installing
 
-Refer to the github wiki for the quick overview and detailed setup.
+Refer to [the github wiki](https://github.com/ccarney16/pterodactyl-containers/wiki) for the quick overview and detailed setup.
 
 ## Contributing
 


### PR DESCRIPTION
There's no direct reference to GH on the docker hub page, this should make it easier to find, especially as the repo isn't the same name as the image.